### PR TITLE
Fixes compilation

### DIFF
--- a/src/cs_smartstone.cpp
+++ b/src/cs_smartstone.cpp
@@ -98,7 +98,7 @@ public:
                         return false;
                     }
 
-                    uint32 relativeID = sSmartstone->GetActionTypeId(serviceType, petData.CreatureId);
+                    uint32 relativeID = sSmartstone->GetActionTypeId(static_cast<ActionType>(serviceType), petData.CreatureId);
 
                     if (target->GetPlayerSetting(ModuleString, relativeID).IsEnabled())
                     {


### PR DESCRIPTION
Fixes the error on compilation:
```
2>C:\Ryans World of Warcraft\Z) Source\azerothcore-wotlk\modules\mod-chromiecraft-smartstone\src\cs_smartstone.cpp(101,54): error C2664: 'uint32_t Smartstone::GetActionTypeId(ActionType,uint32_t)': cannot convert argument 1 from 'uint8' to 'ActionType'
2>    C:\Ryans World of Warcraft\Z) Source\azerothcore-wotlk\modules\mod-chromiecraft-smartstone\src\cs_smartstone.cpp(101,70):
2>    Conversion to enumeration type requires an explicit cast (static_cast, C-style cast or parenthesized function-style cast)
2>    C:\Ryans World of Warcraft\Z) Source\azerothcore-wotlk\modules\mod-chromiecraft-smartstone\src\Smartstone.h(179,38):
2>    see declaration of 'Smartstone::GetActionTypeId'
2>    C:\Ryans World of Warcraft\Z) Source\azerothcore-wotlk\modules\mod-chromiecraft-smartstone\src\cs_smartstone.cpp(101,54):
2>    while trying to match the argument list '(uint8, uint32)'
```

