### PR TITLE
Load and clear account settings around update

### DIFF
--- a/src/cs_smartstone.cpp
+++ b/src/cs_smartstone.cpp
@@ -707,6 +707,8 @@ public:
 
                 uint32 accountId = sCharacterCache->GetCharacterAccountIdByGuid(player.GetGUID());
 
+                sSmartstone->LoadAccountSettings(accountId);
+
                 if (sSmartstone->GetAccountSetting(accountId, serviceType, id).IsEnabled() == add)
                 {
                     sendDupError(costume.Description);
@@ -716,6 +718,7 @@ public:
 
                 sSmartstone->UpdateAccountSetting(accountId, serviceType, settingId, add);
                 sendSuccess(costume.Description);
+                sSmartstone->ClearAccountSettings(accountId);
                 break;
             }
 


### PR DESCRIPTION
Ensure account settings are loaded before checking and invalidate the cache after updating. Adds sSmartstone->LoadAccountSettings(accountId) before GetAccountSetting to guarantee current settings are available, and sSmartstone->ClearAccountSettings(accountId) after UpdateAccountSetting to clear cached data so subsequent reads reflect the update and avoid stale/inconsistent state.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- 
- 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.
